### PR TITLE
Set celery priority in supervisord higher, to start last

### DIFF
--- a/extra/supervisord/celeryd.conf
+++ b/extra/supervisord/celeryd.conf
@@ -29,6 +29,6 @@ stopwaitsecs = 600
 ; taking care of its children as well.
 killasgroup=true
 
-; if rabbitmq is supervised, set its priority higher
-; so it starts first
-priority=998
+; Set Celery priority higher than default (999)
+; so, if rabbitmq is supervised, it will start first.
+priority=1000


### PR DESCRIPTION
Given that supervised rabbitmq has to to start before supervised celery:

According to the [docs](http://supervisord.org/configuration.html) of supervisord:

> Higher priorities indicate programs that start last and shut down first. 


